### PR TITLE
Change HTTP link to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 I'm archiving this for the world to see.
 
-The original source is Marc Laidlaw's website, at http://www.marclaidlaw.com/epistle-3/
+The original source is Marc Laidlaw's website, at https://www.marclaidlaw.com/epistle-3/
 
 If you want a little more info, watch this video by ValveNewsNetwork: https://www.youtube.com/watch?v=urza2sbU68Q
 


### PR DESCRIPTION
End-to-end encryption is important for all data on the web, changing this link to HTTPS protects anyone who clicks it and helps make a more secure internet. 